### PR TITLE
Added support for API 19 (Android 4.4) through API 30 (Android 11)

### DIFF
--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -3,17 +3,17 @@ apply plugin: 'com.android.library'
 ext {
     PUBLISH_GROUP_ID = 'com.zebra.deviceidentifierswrapper'
     PUBLISH_ARTIFACT_ID = 'deviceidentifierswrapper'
-    PUBLISH_VERSION = '0.1'
+    PUBLISH_VERSION = '0.2'
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 19
         targetSdkVersion 29
-        versionCode 1
-        versionName "0.1"
+        versionCode 2
+        versionName "0.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/DeviceIdentifiersWrapper/src/main/AndroidManifest.xml
+++ b/DeviceIdentifiersWrapper/src/main/AndroidManifest.xml
@@ -1,3 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.zebra.deviceidentifierswrapper">
+  <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+  <queries>
+    <package android:name="com.symbol.emdk.emdkservice" />
+  </queries>
 </manifest>

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
@@ -1,5 +1,7 @@
 package com.zebra.deviceidentifierswrapper;
 
+import android.Manifest.permission;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -7,8 +9,11 @@ import android.content.pm.Signature;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
+import android.telephony.TelephonyManager;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
 import java.util.Base64;
 
 public class DIHelper {
@@ -22,12 +27,67 @@ public class DIHelper {
     // This method will return the serial number in the string passed through the onSuccess method
     public static void getSerialNumber(Context context, IDIResultCallbacks callbackInterface)
     {
-        new RetrieveOEMInfoTask().execute(context, Uri.parse("content://oem_info/oem.zebra.secure/build_serial"), callbackInterface);
+        if (android.os.Build.VERSION.SDK_INT < 29) {
+            returnSerialUsingAndroidAPIs(context, callbackInterface);
+        } else {
+            returnSerialUsingZebraAPIs(context, callbackInterface);
+        }
+    }
+
+    @SuppressLint({"MissingPermission", "ObsoleteSdkInt", "HardwareIds"})
+    private static void returnSerialUsingAndroidAPIs(Context context, IDIResultCallbacks callbackInterface) {
+        if (android.os.Build.VERSION.SDK_INT < 26) {
+            callbackInterface.onSuccess(Build.SERIAL);
+        } else {
+            if (ContextCompat.checkSelfPermission(context, permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+                callbackInterface.onSuccess(Build.getSerial());
+            } else {
+                callbackInterface.onError("Please grant READ_PHONE_STATE permission");
+            }
+        }
+    }
+
+    private static void returnSerialUsingZebraAPIs(Context context, IDIResultCallbacks callbackInterface) {
+        new RetrieveOEMInfoTask()
+            .execute(context, Uri.parse("content://oem_info/oem.zebra.secure/build_serial"),
+                callbackInterface);
     }
 
     // This method will return the imei number in the string passed through the onSuccess method
     public static void getIMEINumber(Context context, IDIResultCallbacks callbackInterface)
     {
-        new RetrieveOEMInfoTask().execute(context, Uri.parse("content://oem_info/wan/imei"), callbackInterface);
+        if (android.os.Build.VERSION.SDK_INT < 29) {
+            returnImeiUsingAndroidAPIs(context, callbackInterface);
+        } else {
+            returnImeiUsingZebraAPIs(context, callbackInterface);
+        }
+    }
+
+    @SuppressLint({"MissingPermission", "ObsoleteSdkInt", "HardwareIds" })
+    private static void returnImeiUsingAndroidAPIs(Context context, IDIResultCallbacks callbackInterface) {
+        TelephonyManager telephonyManager = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        if (android.os.Build.VERSION.SDK_INT < 26) {String imei = telephonyManager.getDeviceId();
+            if (imei != null && !imei.isEmpty()) {
+                callbackInterface.onSuccess(imei);
+            } else {
+                callbackInterface.onError("Could not get IMEI number");
+            }
+        } else {
+            if (ContextCompat.checkSelfPermission(context, permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+                String imei = telephonyManager.getImei();
+                if (imei != null && !imei.isEmpty()) {
+                    callbackInterface.onSuccess(imei);
+                } else {
+                    callbackInterface.onError("Could not get IMEI number");
+                }
+            } else {
+                callbackInterface.onError("Please grant READ_PHONE_STATE permission");
+            }
+        }
+    }
+
+    private static void returnImeiUsingZebraAPIs(Context context, IDIResultCallbacks callbackInterface) {
+        new RetrieveOEMInfoTask().execute(context, Uri.parse("content://oem_info/wan/imei"),
+            callbackInterface);
     }
 }

--- a/SampleApplication/build.gradle
+++ b/SampleApplication/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.zebra.emdk_deviceidentifiers_sample"
-        minSdkVersion 29
+        minSdkVersion 19
         targetSdkVersion 29
-        versionCode 1
-        versionName "0.1"
+        versionCode 2
+        versionName "0.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -26,7 +26,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.zebra.deviceidentifierswrapper:deviceidentifierswrapper:0.1'
-    //implementation project(path: ':DeviceIdentifiersWrapper')
+    // implementation project(path: ':DeviceIdentifiersWrapper')
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/SampleApplication/src/main/res/values/strings.xml
+++ b/SampleApplication/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Device ID for Android 10</string>
+    <string name="app_name">Device ID for Android 4.4 -> 11</string>
 </resources>


### PR DESCRIPTION
Hello Laurent, as discussed I've updated your library to support API 19 - 30. I noticed a bug when targeting API 30 that I could not grant access to the OEMIdentifiers, but the issue disappears when targeting API 29. I'll need to follow up with this separately but works for now. 

Could you double check the gradle files in particular please? I haven't seen this method of pushing to jcenter before so I may have overlooked something!