### PR TITLE
V0.8

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-EMDK-DeviceIdentifiers-Sample

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/DeviceIdentifiersWrapper" />
-            <option value="$PROJECT_DIR$/SampleApplication" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
-        versionCode 7
-        versionName "0.7"
+        versionCode 8
+        versionName "0.8"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
-        versionCode 4
-        versionName "0.4"
+        versionCode 5
+        versionName "0.5"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 19
         targetSdkVersion 32
         versionCode 4
         versionName "0.4"

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 28
         targetSdkVersion 32
         versionCode 4
         versionName "0.4"
@@ -24,6 +24,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
 }

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -1,9 +1,5 @@
-apply plugin: 'com.android.library'
-
-ext {
-    PUBLISH_GROUP_ID = 'com.zebra.deviceidentifierswrapper'
-    PUBLISH_ARTIFACT_ID = 'deviceidentifierswrapper'
-    PUBLISH_VERSION = '0.2'
+plugins {
+    id 'com.android.library'
 }
 
 android {

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
-        versionCode 2
-        versionName "0.2"
+        versionCode 4
+        versionName "0.4"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 32
-        versionCode 6
-        versionName "0.6"
+        versionCode 7
+        versionName "0.7"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
@@ -27,8 +27,10 @@ public class DIHelper {
     protected static String sIMEI = null;
     protected static String sSerialNumber = null;
 
-    private static final long MIN_IN_MS = 1000 * 60;
+    public static final long SEC_IN_MS = 1000;
+    public static final long MIN_IN_MS = SEC_IN_MS * 60;
     public static long MAX_EMDK_TIMEOUT_IN_MS = 10 * MIN_IN_MS; // 10 minutes
+    public static long WAIT_PERIOD_BEFORE_RETRY_EMDK_RETRIEVAL_IN_MS = 2 * SEC_IN_MS; // 2 seconds
 
     public static void resetCachedValues()
     {

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
@@ -27,6 +27,9 @@ public class DIHelper {
     protected static String sIMEI = null;
     protected static String sSerialNumber = null;
 
+    private static final long MIN_IN_MS = 1000 * 60;
+    public static long MAX_EMDK_TIMEOUT_IN_MS = 10 * MIN_IN_MS; // 10 minutes
+
     public static void resetCachedValues()
     {
         sIMEI = null;

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIHelper.java
@@ -43,6 +43,10 @@ public class DIHelper {
     {
         if(sSerialNumber != null)
         {
+            if(callbackInterface != null)
+            {
+                callbackInterface.onDebugStatus("Serial number already in cache.");
+            }
             callbackInterface.onSuccess(sSerialNumber);
             return;
         }
@@ -97,6 +101,10 @@ public class DIHelper {
     {
         if(sIMEI != null)
         {
+            if(callbackInterface != null)
+            {
+                callbackInterface.onDebugStatus("IMEI number already in cache.");
+            }
             callbackInterface.onSuccess(sIMEI);
             return;
         }

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -172,6 +172,7 @@ class DIProfileManagerCommand extends DICommandBase {
                     delta = new Date().getTime() - startDate;
                     logMessage("Delta in ms since first EMDK retrieval try: " + delta + "ms stops at " + DIHelper.MAX_EMDK_TIMEOUT_IN_MS + "ms", EMessageType.DEBUG);
                 }
+                logMessage("Could not retrieve EMDK Manager after waiting " + DIHelper.WAIT_PERIOD_BEFORE_RETRY_EMDK_RETRIEVAL_IN_MS/DIHelper.SEC_IN_MS + " seconds. Please contact your administrator or check logcat for any EMDK related error.", EMessageType.ERROR);
             }
         });
         t.setPriority(Thread.MIN_PRIORITY);

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -152,20 +152,25 @@ class DIProfileManagerCommand extends DICommandBase {
 
     private void waitForEMDK()
     {
+        logMessage("EMDKManager error, this could be a BOOT_COMPLETED issue.", EMessageType.DEBUG);
+        logMessage("Starting watcher thread to wait for EMDK initialization.", EMessageType.DEBUG);
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
                 long startDate = new Date().getTime();
                 long delta = 0;
-                long maxWait = 1000 * 60 * 10; // We will try for 10 mns... before stopping
                 while(mEMDKManager == null || delta < DIHelper.MAX_EMDK_TIMEOUT_IN_MS ) {
+                    // Try to initialize EMDK
+                    logMessage("Calling EMDK Initialization method", EMessageType.DEBUG);
                     initializeEMDK();
                     try {
-                        Thread.sleep(5000);
+                        logMessage("Waiting " + DIHelper.WAIT_PERIOD_BEFORE_RETRY_EMDK_RETRIEVAL_IN_MS + " milliseconds before retrying.", EMessageType.DEBUG);
+                        Thread.sleep(DIHelper.WAIT_PERIOD_BEFORE_RETRY_EMDK_RETRIEVAL_IN_MS);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
                     delta = new Date().getTime() - startDate;
+                    logMessage("Delta in ms since first EMDK retrieval try: " + delta + "ms stops at " + DIHelper.MAX_EMDK_TIMEOUT_IN_MS + "ms", EMessageType.DEBUG);
                 }
             }
         });

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -56,6 +56,7 @@ class DIProfileManagerCommand extends DICommandBase {
     // Provides full error description string
     public String msErrorString = "";
 
+    // To prevent multiple initializations at the same time
     private boolean bInitializing = false;
 
     // Status Listener implementation (ensure that we retrieve the profile manager asynchronously
@@ -172,6 +173,7 @@ class DIProfileManagerCommand extends DICommandBase {
                     delta = new Date().getTime() - startDate;
                     logMessage("Delta in ms since first EMDK retrieval try: " + delta + "ms stops at " + DIHelper.MAX_EMDK_TIMEOUT_IN_MS + "ms", EMessageType.DEBUG);
                 }
+                bInitializing = false;
                 logMessage("Could not retrieve EMDK Manager after waiting " + DIHelper.WAIT_PERIOD_BEFORE_RETRY_EMDK_RETRIEVAL_IN_MS/DIHelper.SEC_IN_MS + " seconds. Please contact your administrator or check logcat for any EMDK related error.", EMessageType.ERROR);
             }
         });

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/RetrieveOEMInfoTask.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/RetrieveOEMInfoTask.java
@@ -1,5 +1,6 @@
 package com.zebra.deviceidentifierswrapper;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -163,7 +164,7 @@ class RetrieveOEMInfoTask extends AsyncTask<Object, Void, Boolean> {
             else{
                 for (int i = 0; i < cursor.getColumnCount(); i++) {
                     try {
-                        String data = cursor.getString(cursor.getColumnIndex(cursor.getColumnName(i)));
+                        @SuppressLint("Range") String data = cursor.getString(cursor.getColumnIndex(cursor.getColumnName(i)));
                         resultCallbacks.onSuccess(data);
                         cursor.close();
                         return;

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/RetrieveOEMInfoTask.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/RetrieveOEMInfoTask.java
@@ -107,7 +107,10 @@ class RetrieveOEMInfoTask extends AsyncTask<Object, Void, Boolean> {
                 // You can copy/paste this snippet if you want to provide your own
                 // certificate
                 // TODO: use the following code snippet to extract your custom certificate if necessary
-                final Signature[] arrSignatures = packageInfo.signingInfo.getApkContentsSigners();
+                Signature[] arrSignatures = null;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                    arrSignatures = packageInfo.signingInfo.getApkContentsSigners();
+                }
                 if(arrSignatures == null || arrSignatures.length == 0)
                 {
                     if(callbackInterface != null)
@@ -125,7 +128,10 @@ class RetrieveOEMInfoTask extends AsyncTask<Object, Void, Boolean> {
             final byte[] rawCert = sig.toByteArray();
 
             // Get the certificate as a base64 string
-            String encoded = Base64.getEncoder().encodeToString(rawCert);
+            String encoded = null;
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                encoded = Base64.getEncoder().encodeToString(rawCert);
+            }
 
             profileData =
                     "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 	The IMei and the Serial number will be cached once they get retrieved.
 	The cache can be reset with the method: 
 	DIHelper.resetCachedValues()
-	Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.
+	Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.)
 	To be tested... feel free to report any issue regarding this feature.
 ```
 ## V0.3 : Update for A11

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 ## Important !!
 ```text
         Due to usage of the EMDK and the need to register the application, it is strongly advised to call the methods in your application class
-		Check https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample implementation.
-		It's a basic implementation using static members.
-		Feel free to remove statics and replace them with a better code in terms of architecture.
-		The goal was to pass the idea that theses  number should be retrieved only once, and the best place for it is the Application class.
-		Note that a mechanism has been added in V0.4 to wait for the EMDK in case it would not be available (the classic use case is when your app respond to the BOOT_COMPLETED event that occurs way before the EMDK finishes its initialization)
+	Check https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample implementation.
+	It's a basic implementation using static members.
+	Feel free to remove statics and replace them with a better code in terms of architecture.
+	The goal was to pass the idea that theses  number should be retrieved only once, and the best place for it is the Application class.
+	Note that a mechanism has been added in V0.4 to wait for the EMDK in case it would not be available (the classic use case is when your app respond to the BOOT_COMPLETED event that occurs way before the EMDK finishes its initialization)
 ``` 
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Easy access to serial number and IMEI
 
-Forget about StageNow, EMDK, complexity....
+Forget about StageNow, EMDK, certificates, application signature... complexity....
 
 Just get the serial number and the IMEI number of your Zebra device in one method call (see at the end of this document).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # DeviceIdentifiersWrapper
 
-
-
+## Easy access to serial number and IMEI
+Forget about StageNow, EMDK, complexity....
+Just get the serial number and the IMEI number of your Zebra device in one line of code (see at the end of this document).
+Have fun with Zebra's devices :)
 
 ## Change Log !!! 
 ### 1. Change of REPOSITORY

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 ## Sample Repository
 https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 
-## V0.4 : Basic cache mechanism
+## V0.4 : Basic cache mechanism & Wait for EMDK availability
 ```text
         Added basic cache mechanism.
-		The IMei and the Serial number will be cached once they get retrieved.
-		The cache can be reset with the method: 
-		DIHelper.resetCachedValues()
-		Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.
-		To be tested... feel free to report any issue regarding this feature.
+	The IMei and the Serial number will be cached once they get retrieved.
+	The cache can be reset with the method: 
+	DIHelper.resetCachedValues()
+	Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.
+	To be tested... feel free to report any issue regarding this feature.
 ```
 ## V0.3 : Update for A11
 ```text

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Forget about StageNow, EMDK, complexity....
 
-Just get the serial number and the IMEI number of your Zebra device in one line of code (see at the end of this document).
+Just get the serial number and the IMEI number of your Zebra device in one method call (see at the end of this document).
 
 Have fun with Zebra's devices :)
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,16 @@
 ## Sample Repository
 https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 
-
-## Update for A11
+## V0.4 : Basic cache mechanism
+```text
+        Added basic cache mechanism.
+		The IMei and the Serial number will be cached once they get retrieved.
+		The cache can be reset with the method: 
+		DIHelper.resetCachedValues()
+		Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.
+		To be tested... feel free to report any issue regarding this feature.
+```
+## V0.3 : Update for A11
 ```text
         Update your graddle distribution to >= 7.3.3
         update your compileSdkVersion to 30

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Sample Repository
 https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 
-## V0.4 : Basic cache mechanism & Wait for EMDK availability
+## V0.4 to v0.8 : Basic cache mechanism & Wait for EMDK availability
 ```text
         Added basic cache mechanism.
 	The IMei and the Serial number will be cached once they get retrieved.
@@ -19,6 +19,9 @@ https://github.com/ltrudu/DeviceIdentifiersWrapper-Sample
 	DIHelper.resetCachedValues()
 	Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.)
 	To be tested... feel free to report any issue regarding this feature.
+	Check the sample for a basic implementation.
+	Added lots of logs that will be sent to logCat or to the onDebugStatus callback method.
+	Updated gradle version to release 7.3.3
 ```
 ## V0.3 : Update for A11
 ```text

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # DeviceIdentifiersWrapper
 
 ## Easy access to serial number and IMEI
+
 Forget about StageNow, EMDK, complexity....
+
 Just get the serial number and the IMEI number of your Zebra device in one line of code (see at the end of this document).
+
 Have fun with Zebra's devices :)
+
+
+
+
 
 ## Change Log !!! 
 ### 1. Change of REPOSITORY

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        jcenter()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:4.0.0"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
+plugins {
+    id 'com.android.application' version '7.2.2' apply false
+    id 'com.android.library' version '7.2.2' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':SampleApplication',':DeviceIdentifiersWrapper'
-rootProject.name = "EMDK-DeviceIdentifiers-Sample"
+include ':DeviceIdentifiersWrapper'
+rootProject.name = "DeviceIdentifiersWrapper"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,22 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        jcenter()
+        maven { url 'https://jitpack.io' }
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+        maven { url 'https://jitpack.io' }
+    }
+}
+
+
 include ':DeviceIdentifiersWrapper'
 rootProject.name = "DeviceIdentifiersWrapper"


### PR DESCRIPTION
Added basic cache mechanism.
	The IMei and the Serial number will be cached once they get retrieved.
	The cache can be reset with the method: 
	DIHelper.resetCachedValues()
	Added a mechanism to wait for the EMDK if it is not available (when responding to the BOOT_COMPLETED event for ex.)
	To be tested... feel free to report any issue regarding this feature.
	Check the sample for a basic implementation.
	Added lots of logs that will be sent to logCat or to the onDebugStatus callback method.
	Updated gradle version to release 7.3.3