### PR TITLE
A13 Freeze Fix

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CMakeSettings">
     <configurations>

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 10
-        versionName "0.9.1"
+        versionCode 11
+        versionName "0.9.2"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 9
-        versionName "0.9"
+        versionCode 10
+        versionName "0.9.1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/DeviceIdentifiersWrapper/build.gradle
+++ b/DeviceIdentifiersWrapper/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 11
-        versionName "0.9.2"
+        versionCode 12
+        versionName "0.9.3"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -65,6 +65,7 @@ class DIProfileManagerCommand extends DICommandBase {
         public void onStatus(EMDKManager.StatusData statusData, EMDKBase emdkBase) {
             if(statusData.getResult() == EMDKResults.STATUS_CODE.SUCCESS)
             {
+                logMessage("Profile manager retrieved.", EMessageType.DEBUG);
                 onProfileManagerInitialized((ProfileManager)emdkBase);
             }
             else
@@ -188,6 +189,7 @@ class DIProfileManagerCommand extends DICommandBase {
         if(mProfileManager == null)
         {
             try {
+                logMessage("Requesting profile manager.", EMessageType.DEBUG);
                 emdkManager.getInstanceAsync(EMDKManager.FEATURE_TYPE.PROFILE, mStatusListener);
             } catch (EMDKException e) {
                 logMessage("Error when trying to retrieve profile manager: " + e.getMessage(), EMessageType.ERROR);
@@ -226,7 +228,7 @@ class DIProfileManagerCommand extends DICommandBase {
     {
         mProfileManager = profileManager;
         bInitializing = false;
-        logMessage("Profile Manager retrieved.", EMessageType.DEBUG);
+        logMessage("Processing MX Content", EMessageType.DEBUG);
         processMXContent();
     }
 
@@ -263,6 +265,7 @@ class DIProfileManagerCommand extends DICommandBase {
         String[] params = new String[1];
         params[0] = msProfileData;
 
+        logMessage("Processing profile :" + msProfileData, EMessageType.VERBOSE);
         EMDKResults results = mProfileManager.processProfile(msProfileName, ProfileManager.PROFILE_FLAG.SET, params);
 
         //Check the return status of processProfile

--- a/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
+++ b/DeviceIdentifiersWrapper/src/main/java/com/zebra/deviceidentifierswrapper/DIProfileManagerCommand.java
@@ -2,6 +2,7 @@ package com.zebra.deviceidentifierswrapper;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Xml;
@@ -190,7 +191,20 @@ class DIProfileManagerCommand extends DICommandBase {
         {
             try {
                 logMessage("Requesting profile manager.", EMessageType.DEBUG);
-                emdkManager.getInstanceAsync(EMDKManager.FEATURE_TYPE.PROFILE, mStatusListener);
+                logMessage("Current API version: " + android.os.Build.VERSION.SDK_INT, EMessageType.VERBOSE);
+                if(android.os.Build.VERSION.SDK_INT < 33) {
+                    logMessage("Requesting profile manager Asynchonously", EMessageType.DEBUG);
+                    emdkManager.getInstanceAsync(EMDKManager.FEATURE_TYPE.PROFILE, mStatusListener);
+                }
+                else
+                {
+                    logMessage("Requesting profile manager synchronized", EMessageType.DEBUG);
+                    ProfileManager profileManager = (ProfileManager) emdkManager.getInstance(EMDKManager.FEATURE_TYPE.PROFILE);
+                    if(profileManager != null)
+                    {
+                        onProfileManagerInitialized(profileManager);
+                    }
+                }
             } catch (EMDKException e) {
                 logMessage("Error when trying to retrieve profile manager: " + e.getMessage(), EMessageType.ERROR);
             }


### PR DESCRIPTION
On some devices, the library was freezing while attempting to get the profile manager asynchronously.
The code has been modified to get the manager synchronously on A13 BSPs while waiting for a fix.